### PR TITLE
feat(cms): Upload Document - Only support single uploads

### DIFF
--- a/backend/endpoints/models/volume_models.go
+++ b/backend/endpoints/models/volume_models.go
@@ -18,8 +18,9 @@ type (
 
 	// ValidImageUploadRequest is the request model for an handler that uploads an IMAGE to a docker volume
 	ValidDocumentUploadRequest struct {
-		DocumentID uuid.UUID `schema:"DocumentID,required"`
-		Content    string    `schema:"Content,required"` // TODO: Add check that content is valid JSON
+		Parent       uuid.UUID `schema:"Parent,required"`
+		DocumentName string    `schema:"DocumentName,required"`
+		Content      string    `schema:"Content,required"` // TODO: Add check that content is valid JSON
 	}
 
 	// ValidPublishDocumentRequest is the request model for any handler that publishes a document


### PR DESCRIPTION
Modifying upload document to only support uploading a document once, prevents issues with ppl overriding data