### PR TITLE
[CMS-306] Thomas L - Onboarding

### DIFF
--- a/backend/endpoints/models/user_models.go
+++ b/backend/endpoints/models/user_models.go
@@ -32,7 +32,7 @@ func (u *User) IsValidEmail() bool {
 
 // UserExists just checks if a user has a valid password
 func (u *User) UserExists(personRepo repositories.PersonRepository) bool {
-	hashedPassword := u.hashPassword()
+	hashedPassword := u.HashPassword()
 
 	return personRepo.PersonExists(repositories.Person{
 		Email:    u.Email,
@@ -40,8 +40,8 @@ func (u *User) UserExists(personRepo repositories.PersonRepository) bool {
 	})
 }
 
-// hashPassword hashes a user's password
-func (u *User) hashPassword() string {
+// HashPassword hashes a user's password
+func (u *User) HashPassword() string {
 	hashedBytes := sha256.Sum256([]byte(u.Password))
 	return string(hashedBytes[:])
 }

--- a/backend/endpoints/tests/auth_test.go
+++ b/backend/endpoints/tests/auth_test.go
@@ -1,10 +1,46 @@
 package tests
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
+	"cms.csesoc.unsw.edu.au/endpoints"
+	"cms.csesoc.unsw.edu.au/endpoints/models"
+
+	"cms.csesoc.unsw.edu.au/database/repositories"
+	. "cms.csesoc.unsw.edu.au/database/repositories/mocks"
+	. "cms.csesoc.unsw.edu.au/endpoints/mocks"
 )
 
+// Test [endpoints.LoginHandler] succeeds on correct input.
 func TestLogin(t *testing.T) {
+	form := models.User {Email: "thomas.liang1@student.unsw.edu.au", Password: "backendnumberone"}
+	responseRecorder := httptest.NewRecorder()
+	request := httptest.NewRequest("POST", "/login", nil)
+
+	// Set up mock-test boilerplate.
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+	// LoginHandler queries the person repository of the dependency factory it is given for the user details.
+	mockPersonRepository := NewMockIPersonRepository(controller)
+	// Fake a repository entry.
+	person := repositories.Person {Email: form.Email, Password: form.HashPassword()}
+	mockPersonRepository.EXPECT().PersonExists(person).Return(true)
+	mockDependencyFactory := NewMockDependencyFactory(controller)
+	mockDependencyFactory.EXPECT().GetPersonsRepo().Return(mockPersonRepository)
+
+	response := endpoints.LoginHandler(form, responseRecorder, request, mockDependencyFactory)
+
+	// The fun happens here!
+	const statusCode = http.StatusMovedPermanently
+	assert := assert.New(t)
+	assert.Equal(statusCode, response.Status)
+	// The written status should align with the returned status.
+	assert.Equal(statusCode, responseRecorder.Result().StatusCode)
 }
 
 func TestLogout(t *testing.T) {


### PR DESCRIPTION
Hello!

This adds tests for `TestLogin` and `TestLogout` in [`auth_endpoints.go`](https://github.com/csesoc/website/blob/CMS-306/backend/endpoints/auth_endpoints.go). Sorry for taking so long.

They test only the current behaviour on the typical success case, that is, logging in as a user that exists and logging out a user that has logged in. There is definitely space to add tests for error cases.

Part of the success behaviour is that `TestLogin` returns the status code [`301 Moved Permanently`](https://http.cat/301), which seems dubious to me. That seems more appropriate for deprecated routes, especially since RFC 2616 says that it indicates the client should update references to point to the redirect and that the response is cacheable.

Lastly, I exported `(u *User) HashPassword` (previously `(u *User) hashPassword`) from `endpoints.models`. I thought how the tests generated entries in the person repository should be coupled to how the implementation does it.