### PR TITLE
docs: correct docker command from `volumes` to `volume`

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,4 +54,4 @@ Our editor uses quite a few algorithms so below is a list of resources you can u
 - A: google docker desktop WSL2 not detecting docker
 
 - Q: Docker is taking up alot of space how to remove?
-- A: docker is a ram/storage drainer but, you can remove useless volumes, run `docker volumes prune`
+- A: docker is a ram/storage drainer but, you can remove useless volumes, run `docker volume prune`


### PR DESCRIPTION
running the current command returns the following output:
```
docker: 'volumes' is not a docker command.
See 'docker --help'
```
because `volumes` is not a docker command, but `volume` is, so this PR fixes this docker command by changing `docker volumes` to `docker volume` so that it uses the correct docker command that doesn't return an error, as `docker volume` is valid