### PR TITLE
Fixed Responsiveness Clipping on Mobile

### DIFF
--- a/next/src/components/start/advice/AdviceView.tsx
+++ b/next/src/components/start/advice/AdviceView.tsx
@@ -48,6 +48,8 @@ const MainContainer = styled.div`
   flex: 1;
   display: flex;
   flex-direction: column;
+  justify-content: center;
+  width: 100%;
 `;
 
 const InfoCardsContainer = styled.div`
@@ -61,6 +63,7 @@ const InfoCardsContainer = styled.div`
   right: 0;
   top:0;
   bottom: 30px;
+
   
   @media ${device.laptop} {
     justify-content: space-around;

--- a/next/src/components/start/advice/InfoCard.tsx
+++ b/next/src/components/start/advice/InfoCard.tsx
@@ -115,6 +115,7 @@ const Button = styled.button`
   font-size: 20px;
   height: 40px;
 
+
   @media ${device.laptop} {
     font-size: 16px;
     height: 32px;

--- a/next/src/components/start/connect/ConnectView.tsx
+++ b/next/src/components/start/connect/ConnectView.tsx
@@ -14,6 +14,8 @@ import InstagramScreenshot from "../../../../public/assets/csesoc_instagram.png"
 import YoutubeScreenshot from "../../../../public/assets/csesoc_youtube.png";
 import SpotifyScreenshot from "../../../../public/assets/csesoc_spotify.png";
 
+import { device } from "../../../styles/device";
+
 const MainContainer = styled.div`
   display: flex;
   flex-direction: column-reverse;
@@ -40,7 +42,25 @@ const Preview = styled.div`
 const SocialIcons = styled.div`
   display: flex;
   justify-content: center;
-  gap: 2rem;
+
+  gap: 0.5rem;
+
+  @media ${device.tablet} {
+    gap: 2rem;
+  }
+
+  
+`;
+
+const SocialIconImageContainer = styled.div`
+  position: relative;
+  height: 40px;
+  width: 40px;
+
+  @media ${device.tablet} {
+    height: 60px;
+    width: 60px;
+  }
 `;
 
 const Button = styled.button<{ active?: boolean }>`
@@ -50,15 +70,18 @@ const Button = styled.button<{ active?: boolean }>`
   background: none;
   border: none;
   cursor: pointer;
-  width: 60px;
-  height: 60px;
   border-radius: 100%;
+  padding: 0.5rem;
 
   ${({ active }) =>
     active &&
     `
       box-shadow: 0 0 0 4px var(--primary-purple);
     `}
+
+  @media ${device.tablet} {
+    padding: 1rem;
+  }
 `;
 
 const socialIcons = [
@@ -83,7 +106,7 @@ const socialIcons = [
   {
     name: "YouTube",
     icon: YoutubeLogo,
-    link: "cseso.cc/youtube",
+    link: "https://cseso.cc/youtube",
     screenshot: YoutubeScreenshot,
   },
   {
@@ -102,7 +125,9 @@ export default function ConnectView() {
       <SocialIcons>
         {socialIcons.map(({ name, icon }) => (
           <Button active={name === activeTab} key={name} onClick={() => setActiveTab(name)}>
-            <Image src={icon.src} alt={name} width={50} height={50} />
+            <SocialIconImageContainer>
+              <Image src={icon.src} alt={name} objectFit="cover" layout="fill" />
+            </SocialIconImageContainer>
           </Button>
         ))}
       </SocialIcons>

--- a/next/src/components/start/welcome/WelcomeView.tsx
+++ b/next/src/components/start/welcome/WelcomeView.tsx
@@ -9,6 +9,7 @@ const MainContainer = styled.div`
   justify-content: center;
   align-items: center;
   row-gap: 30px;
+  width: 100%;
 `;
 
 const blink = keyframes`  


### PR DESCRIPTION
The main issue was with the ConnectView page overflowing due to no responsiveness on the icons. This was a problem because the way we animate smoothly between the pages is by transformX 100% and so one page overflowing results in issues for the other pages

### Welcome
<img width="692" alt="Screen Shot 2023-02-04 at 10 33 08 pm" src="https://user-images.githubusercontent.com/49261993/216765023-71185839-cb2d-49f4-89e6-d65d40ece5ca.png">

### Connect
<img width="507" alt="Screen Shot 2023-02-04 at 10 33 23 pm" src="https://user-images.githubusercontent.com/49261993/216765033-63e084aa-bc66-4a88-b92c-a5c9cad0555f.png">

### Advice
<img width="584" alt="Screen Shot 2023-02-04 at 10 33 55 pm" src="https://user-images.githubusercontent.com/49261993/216765051-8ecce700-2a89-4094-94e6-ee7efe714a9a.png">

### Enrolment
<img width="612" alt="Screen Shot 2023-02-04 at 10 34 13 pm" src="https://user-images.githubusercontent.com/49261993/216765058-13259c75-0067-4904-8d52-038b34971ee3.png">

### Events
Yes this one is a bit doomed but we'll make another PR for that
<img width="492" alt="Screen Shot 2023-02-04 at 10 34 38 pm" src="https://user-images.githubusercontent.com/49261993/216765072-31b6be0b-e9d5-4b52-981b-2489e9f5b01d.png">
