### PR TITLE
[WEB-1_double_click_file] Implemented double click navigate to file.

### DIFF
--- a/frontend/src/packages/dashboard/components/FileRenderer/FileContainer.tsx
+++ b/frontend/src/packages/dashboard/components/FileRenderer/FileContainer.tsx
@@ -6,6 +6,7 @@
 
 import React from "react";
 import styled, { css } from "styled-components";
+import { useNavigate } from "react-router-dom";
 import Renamable from "./Renamable";
 
 type Props = {
@@ -42,6 +43,15 @@ function FileContainer({ name, id, selectedFile, setSelectedFile }: Props) {
     setSelectedFile(id);
   };
 
+  const navigate = useNavigate();
+  const handleDoubleClick = () => {
+    console.log(id);
+    setSelectedFile(id);
+    if (selectedFile !== null) {
+      navigate("/editor/" + selectedFile, { replace: false }), [navigate];
+    }
+  };
+
   return (
     <div
       style={{
@@ -51,7 +61,11 @@ function FileContainer({ name, id, selectedFile, setSelectedFile }: Props) {
         padding: "35px",
       }}
     >
-      <IconContainer onClick={handleClick} active={selectedFile == id} />
+      <IconContainer
+        onClick={handleClick}
+        onDoubleClick={handleDoubleClick}
+        active={selectedFile == id}
+      />
       <Renamable name={name} id={id} />
     </div>
   );


### PR DESCRIPTION
### Why the changes are required?
Currently, in order to edit a document, the user has to select the file and then select the edit button. Double clicking let's user more fluidly access their document.

### Changes
 - Implemented onDoubleClick and navigate to editor in FileContainer.tsx

### Screenshots
![Screenshot 2023-02-25 144912](https://user-images.githubusercontent.com/86332745/221334600-f5d69c7a-9b6d-4e3c-8317-dc13f6a8d0e3.png)

### Comments