### PR TITLE
[WEB-3] add icons to new page, new folder, and edit button

### DIFF
--- a/frontend/src/packages/dashboard/components/SideBar/SideBar.tsx
+++ b/frontend/src/packages/dashboard/components/SideBar/SideBar.tsx
@@ -62,8 +62,16 @@ const ButtonGroup = styled.div`
   grid-gap: 30px;
 `;
 
-const ButtonIcon = styled.span`
-  margin: 0.1rem 0.6rem 0 0;
+const ButtonIcon = styled.div`
+  margin: 0 1rem 0;
+  display: flex;
+  align-items: center
+`;
+
+const ButtonText = styled.p`
+  flex-grow: 2;
+  text-align: left;
+  margin: 0.2rem 0;
 `;
 
 interface SideBarButtonProps {
@@ -79,6 +87,7 @@ const SidebarButton = styled(Button)<SideBarButtonProps>`
     border-radius: 20px;
     text-transform: none;
     color: black;
+    display: flex;
     &:hover {
       transform: scale(1.04);
       background-color: darkgrey;
@@ -155,7 +164,9 @@ export default function SideBar({
             <ButtonIcon>
               <DescriptionOutlinedIcon/>
             </ButtonIcon>
-            New page
+            <ButtonText>
+              New page
+            </ButtonText>
           </SidebarButton>
           <SidebarButton
             bgcolor="#b4c6ff"
@@ -165,7 +176,9 @@ export default function SideBar({
             <ButtonIcon>
               <FolderOutlinedIcon/>
             </ButtonIcon>
-            New folder
+            <ButtonText>
+              New folder
+            </ButtonText>
           </SidebarButton>
         </ButtonGroup>
         <ButtonGroup>
@@ -173,7 +186,9 @@ export default function SideBar({
             <ButtonIcon>
               <EditOutlinedIcon/>
             </ButtonIcon>
-            Edit
+            <ButtonText>
+              Edit
+            </ButtonText>
           </SidebarButton>
           {/* <SidebarButton bgcolor="#B8E8E8">
             Feature

--- a/frontend/src/packages/dashboard/components/SideBar/SideBar.tsx
+++ b/frontend/src/packages/dashboard/components/SideBar/SideBar.tsx
@@ -4,6 +4,9 @@ import Button from "@mui/material/Button";
 import { useNavigate } from "react-router-dom";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import MenuIcon from "@mui/icons-material/Menu";
+import DescriptionOutlinedIcon from '@mui/icons-material/DescriptionOutlined';
+import FolderOutlinedIcon from '@mui/icons-material/FolderOutlined';
+import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
 
 const Container = styled.div`
   position: relative;
@@ -57,6 +60,10 @@ const ButtonGroup = styled.div`
   flex-direction: column;
   align-items: center;
   grid-gap: 30px;
+`;
+
+const ButtonIcon = styled.span`
+  margin: 0.1rem 0.6rem 0 0;
 `;
 
 interface SideBarButtonProps {
@@ -145,6 +152,9 @@ export default function SideBar({
             onClick={handleNewFile}
             data-anchor="NewPageButton"
           >
+            <ButtonIcon>
+              <DescriptionOutlinedIcon/>
+            </ButtonIcon>
             New page
           </SidebarButton>
           <SidebarButton
@@ -152,11 +162,17 @@ export default function SideBar({
             onClick={handleNewFolder}
             data-anchor="NewFolderButton"
           >
+            <ButtonIcon>
+              <FolderOutlinedIcon/>
+            </ButtonIcon>
             New folder
           </SidebarButton>
         </ButtonGroup>
         <ButtonGroup>
           <SidebarButton bgcolor="white" onClick={handleEdit}>
+            <ButtonIcon>
+              <EditOutlinedIcon/>
+            </ButtonIcon>
             Edit
           </SidebarButton>
           {/* <SidebarButton bgcolor="#B8E8E8">


### PR DESCRIPTION
### Why the changes are required
Currently, the buttons on the sidebar have no icons. By adding universally recognised icons, users will be able to instantly know the functionality of each button.

### Changes
In `frontend/src/packages/dashboard/components/Sidebar/Sidebar.tsx`:
- Edited styled component `SidebarButton` to have `display: flex`, in order to align the button icons and text properly.
- Created new styled components `ButtonIcon` and `ButtonText` to style the individual components of each button.
- Imported icons for each of the three buttons from the MUI Icon Library that most closely resembled those specified in the ticket. Integrated them into each button as required.

### Screenshots
![Screenshot_20230226_023458](https://user-images.githubusercontent.com/79197816/221390925-f97a4c7a-2494-46cc-ba61-e24c67e27e35.png)
