### PR TITLE
Web2 editor back button

### DIFF
--- a/frontend/src/deprecated/components/Editor/EditorHeader.tsx
+++ b/frontend/src/deprecated/components/Editor/EditorHeader.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import styled from 'styled-components';
 import Button from '@mui/material/Button';
+import IconButton from "@mui/material/IconButton";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import { useNavigate } from 'react-router-dom';
+
 
 const Container = styled.div`
   height: 50px;
@@ -40,9 +44,20 @@ const ButtonStyle = styled(Button)`
 /* Preview and text to be changed into a dropdown menu */
 
 const EditorHeader: React.FC = () => {
+
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    navigate("/");
+  };
+
   return (
     <Container>
       <HeaderFlex>
+        <IconButton aria-label="back" onClick={() => handleClick()}>
+          <ArrowBackIcon fontSize="inherit" />
+        </IconButton>
+
         {/* <ButtonGroup>
           <ButtonStyle>
           ←


### PR DESCRIPTION
Why the changes are required
- easier to navigate back to the dashboard from the editor page

Changes
- imported mui button icons to be consistent with directory button
- added useNavigate hook to redirect to dashboard when button is clicked