### PR TITLE
[WEB-10] Handle enter key press when naming new file/folder

### DIFF
--- a/frontend/src/packages/dashboard/components/ConfirmationModal/ConfirmationWindow.tsx
+++ b/frontend/src/packages/dashboard/components/ConfirmationModal/ConfirmationWindow.tsx
@@ -77,6 +77,12 @@ export default function ConfirmationWindow({
     setInputValue(value);
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      handleSubmit();
+    }
+  }
+
   return (
     <Modal
       open={open}
@@ -93,6 +99,7 @@ export default function ConfirmationWindow({
           <TextField
             value={inputValue}
             onChange={handleChange}
+            onKeyDown={handleKeyDown}
             sx={{ marginRight: "10px" }}
           />
           <Button background="#73EEDC" onClick={handleSubmit}>


### PR DESCRIPTION
### Why the changes are required?
When creating a new file/folder the popup modal does not accept the enter key press to submit. Handling the enter key press provides better accessibility.
### Changes
- added an onKeyDown event to the submission textfield in ConfirmationWindow.tsx
- created the event handler (handleKeyDown) that calls handleSubmit when pressed
### Screenshots

### Comments