### PR TITLE
[WEB-4] [EDITOR] move sync and publish buttons to the top of the editor page

### DIFF
--- a/frontend/src/deprecated/components/Editor/EditorHeader.tsx
+++ b/frontend/src/deprecated/components/Editor/EditorHeader.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import Button from '@mui/material/Button';
 
 const Container = styled.div`
-  height: 50px;
+  height: 65px;
   background: #A09FE3;
   width: 100%;
 `
@@ -16,7 +16,7 @@ const HeaderFlex = styled.div`
 display: flex;
 flex-direction: row;
 flex-wrap: nowrap;
-justify-content: space-between;
+justify-content: flex-end;
 align-items: center;
 padding: 0.3rem 0.5rem;
 `
@@ -39,10 +39,11 @@ const ButtonStyle = styled(Button)`
 `
 /* Preview and text to be changed into a dropdown menu */
 
-const EditorHeader: React.FC = () => {
+const EditorHeader: React.FC = (props) => {
   return (
     <Container>
       <HeaderFlex>
+        {props.children}
         {/* <ButtonGroup>
           <ButtonStyle>
           ←

--- a/frontend/src/packages/editor/index.tsx
+++ b/frontend/src/packages/editor/index.tsx
@@ -82,14 +82,15 @@ const EditorPage: FC = () => {
 
   return (
     <div style={{ height: "100%" }}>
-      <EditorHeader />
+      <EditorHeader>
+          <SyncDocument onClick={() => syncDocument()} />
+          <PublishDocument onClick={() => publishDocument(id ?? "")} />
+      </EditorHeader>
       <Container>
         {blocks.map((block, idx) => createBlock(block, idx, focusedId === idx))}
         <InsertContentWrapper>
           <CreateHeadingBlock onClick={buildButtonClickHandler("heading")} />
           <CreateContentBlock onClick={buildButtonClickHandler("paragraph")} />
-          <SyncDocument onClick={() => syncDocument()} />
-          <PublishDocument onClick={() => publishDocument(id ?? "")} />
         </InsertContentWrapper>
       </Container>
     </div>


### PR DESCRIPTION
### Why the changes are required?
Currently in the editor, the sync and publish buttons are positioned next to the `insert heading/content block` buttons. As these buttons don't directly relate to the editing of the document, it is best to position them separately in the top right corner.

### Changes
In  `frontend/src/packages/editor/index.tsx`:
- Changed the `EditorHeader` component to have both a opening and closing tag, in order to nest the sync and publish buttons within it.
- Nested `SyncDocument` and `PublishDocument` components within `EditorHeader`.

In `frontend/src/deprecated/components/Editor/EditorHeader.tsx`:
- Increased header size from `50px` to `65px`, in order to fully contain the sync and publish buttons without overflow.
- In `HeaderFlex` component, set `justify-content` to `flex-end` in order to align the buttons to the right of the header.
- Modified `EditorHeader` to have `props` in order to pass in sync and publish buttons as children.

### Screenshots
![image](https://user-images.githubusercontent.com/79197816/222893786-360ea9e3-2731-4997-8d1d-304616cda916.png)

### Comments
- I noticed that the header component currently used is in a deprecated folder. Will we be creating a new header component and file later on?