### PR TITLE
remove input box when user deselects the title of a folder or a file

### DIFF
--- a/frontend/src/packages/dashboard/components/FileRenderer/Renamable.tsx
+++ b/frontend/src/packages/dashboard/components/FileRenderer/Renamable.tsx
@@ -39,7 +39,7 @@ export default function Renamable({ name, id }: Props) {
           }}
           type="text"
           value={inputName}
-          onChange={(event) => {setInputName(event.target.value)}}
+          onChange={(event) => setInputName(event.target.value)}
           onKeyDown={(event) => {
             if (event.key === "Enter" || event.key === "Escape") {
               if (event.key === "Enter") {

--- a/frontend/src/packages/dashboard/components/FileRenderer/Renamable.tsx
+++ b/frontend/src/packages/dashboard/components/FileRenderer/Renamable.tsx
@@ -26,6 +26,7 @@ export default function Renamable({ name, id }: Props) {
     dispatch(renameFileEntityAction(newPayload));
   };
 
+ 
   return (
     <>
       {toggle ? (
@@ -38,7 +39,7 @@ export default function Renamable({ name, id }: Props) {
           }}
           type="text"
           value={inputName}
-          onChange={(event) => setInputName(event.target.value)}
+          onChange={(event) => {setInputName(event.target.value)}}
           onKeyDown={(event) => {
             if (event.key === "Enter" || event.key === "Escape") {
               if (event.key === "Enter") {
@@ -49,6 +50,14 @@ export default function Renamable({ name, id }: Props) {
               event.stopPropagation();
             }
           }}
+
+          onBlur={(event) => {
+              handleRename(inputName);
+              setToggle(true);
+              event.preventDefault();
+              event.stopPropagation();
+          }}
+        autoFocus
         />
       )}
     </>


### PR DESCRIPTION
Why the changes are required

- the input box persists and the user may end up with multiple input boxes for changing the names of the files and folders

Changes

- the input box is automatically focused once the name is double clicked
- clicking outside the box will set the name 
