### PR TITLE
[WEB-20] Clicking on folder pill in breadcrumb path redirects user to that folder

### DIFF
--- a/frontend/src/packages/dashboard/Dashboard.tsx
+++ b/frontend/src/packages/dashboard/Dashboard.tsx
@@ -6,9 +6,14 @@ import { Breadcrumbs, Link } from "@mui/material";
 // local imports
 import SideBar from "src/packages/dashboard/components/SideBar/SideBar";
 import Renderer from "./components/FileRenderer/Renderer";
-import { initAction, traverseBackFolder } from "./state/folders/actions";
+import {
+  initAction,
+  traverseBackFolder,
+  traverseIntoFolder,
+} from "./state/folders/actions";
 import ConfirmationWindow from "./components/ConfirmationModal/ConfirmationWindow";
 import Directory from "./components/Directory";
+import { getFolderState } from "./api/helpers";
 
 const Container = styled.div`
   display: flex;
@@ -33,12 +38,12 @@ export default function Dashboard() {
   );
 
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
-  // const parentFolder = getFolderState().parentFolder;
+  const parentFolder = getFolderState().parentFolder;
   const dispatch = useDispatch();
-
   useEffect(() => {
     // fetches all folders and files from backend and displays it
-    dispatch(initAction());
+    // dispatch(initAction());
+    dispatch(traverseIntoFolder(parentFolder));
   }, []);
 
   return (

--- a/frontend/src/packages/dashboard/components/Directory.tsx
+++ b/frontend/src/packages/dashboard/components/Directory.tsx
@@ -45,6 +45,7 @@ const BreadcrumbItem = customStyle(Chip)(({ theme }) => {
   };
 });
 
+// Wrapper used for breadcrumb to individualise onClick for each pill
 type BreadcrumbItemWrapperProps = {
   folderObject: PathObject;
 };

--- a/frontend/src/packages/dashboard/components/Directory.tsx
+++ b/frontend/src/packages/dashboard/components/Directory.tsx
@@ -7,8 +7,12 @@ import { useDispatch } from "react-redux";
 import IconButton from "@mui/material/IconButton";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 
-import { traverseBackFolder } from "../state/folders/actions";
+import {
+  traverseBackFolder,
+  traverseIntoFolder,
+} from "../state/folders/actions";
 import { getFolderState } from "../api/helpers";
+import { setDirectory } from "../state/folders/reducers";
 
 const DirectoryFlex = styled.div`
   display: flex;
@@ -22,7 +26,7 @@ const DirectoryFlex = styled.div`
 
 const BreadcrumbItem = customStyle(Chip)(({ theme }) => {
   const backgroundColor =
-    theme.palette.mode === 'light'
+    theme.palette.mode === "light"
       ? theme.palette.grey[200]
       : theme.palette.grey[800];
   return {
@@ -48,6 +52,15 @@ export default function Directory() {
     dispatch(traverseBackFolder(parentFolder));
   };
 
+  const folderState = getFolderState();
+
+  const handleClickBreadcrumbItem = (
+    event: React.MouseEvent<HTMLDivElement, MouseEvent>
+  ) => {
+    dispatch(traverseIntoFolder("3f4b7ac5-2b08-43fe-87cd-4dd1d1be8455"));
+    console.log("getFolderState", folderState);
+  };
+
   return (
     <DirectoryFlex>
       <IconButton aria-label="back" onClick={() => handleClick()}>
@@ -57,7 +70,13 @@ export default function Directory() {
         {getFolderState()
           .path.split("/")
           .map((folder, i) => {
-            return <BreadcrumbItem key={i} label={folder} />;
+            return (
+              <BreadcrumbItem
+                key={i}
+                label={folder}
+                onClick={handleClickBreadcrumbItem}
+              />
+            );
           })}
       </Breadcrumbs>
     </DirectoryFlex>

--- a/frontend/src/packages/dashboard/components/Directory.tsx
+++ b/frontend/src/packages/dashboard/components/Directory.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Breadcrumbs } from "@mui/material";
 import Chip from "@mui/material/Chip";
 import { emphasize, styled as customStyle } from "@mui/material/styles";
@@ -12,7 +12,7 @@ import {
   traverseIntoFolder,
 } from "../state/folders/actions";
 import { getFolderState } from "../api/helpers";
-import { setDirectory } from "../state/folders/reducers";
+import { PathObject } from "../state/folders/types";
 
 const DirectoryFlex = styled.div`
   display: flex;
@@ -29,6 +29,7 @@ const BreadcrumbItem = customStyle(Chip)(({ theme }) => {
     theme.palette.mode === "light"
       ? theme.palette.grey[200]
       : theme.palette.grey[800];
+
   return {
     backgroundColor,
     height: theme.spacing(3),
@@ -44,6 +45,27 @@ const BreadcrumbItem = customStyle(Chip)(({ theme }) => {
   };
 });
 
+type BreadcrumbItemWrapperProps = {
+  folderObject: PathObject;
+};
+
+const BreadcrumbItemWrapper = ({
+  folderObject,
+}: BreadcrumbItemWrapperProps) => {
+  const dispatch = useDispatch();
+  const handleClickBreadcrumbItem = () => {
+    dispatch(traverseIntoFolder(folderObject.folderId));
+  };
+  return (
+    <div>
+      <BreadcrumbItem
+        label={folderObject.folderName}
+        onClick={handleClickBreadcrumbItem}
+      />
+    </div>
+  );
+};
+
 export default function Directory() {
   const dispatch = useDispatch();
   const parentFolder = getFolderState().parentFolder;
@@ -51,33 +73,15 @@ export default function Directory() {
   const handleClick = () => {
     dispatch(traverseBackFolder(parentFolder));
   };
-
-  const folderState = getFolderState();
-
-  const handleClickBreadcrumbItem = (
-    event: React.MouseEvent<HTMLDivElement, MouseEvent>
-  ) => {
-    dispatch(traverseIntoFolder("3f4b7ac5-2b08-43fe-87cd-4dd1d1be8455"));
-    console.log("getFolderState", folderState);
-  };
-
   return (
     <DirectoryFlex>
       <IconButton aria-label="back" onClick={() => handleClick()}>
         <ArrowBackIcon fontSize="inherit" />
       </IconButton>
       <Breadcrumbs aria-label="breadcrumb">
-        {getFolderState()
-          .path.split("/")
-          .map((folder, i) => {
-            return (
-              <BreadcrumbItem
-                key={i}
-                label={folder}
-                onClick={handleClickBreadcrumbItem}
-              />
-            );
-          })}
+        {getFolderState().path.map((folderObject, i) => {
+          return <BreadcrumbItemWrapper folderObject={folderObject} key={i} />;
+        })}
       </Breadcrumbs>
     </DirectoryFlex>
   );

--- a/frontend/src/packages/dashboard/state/folders/initial-state.ts
+++ b/frontend/src/packages/dashboard/state/folders/initial-state.ts
@@ -4,6 +4,6 @@ const ROOT_UUID = "00000000-0000-0000-0000-000000000000";
 
 export const initialState: sliceState = {
   parentFolder: ROOT_UUID,
-  path: "root",
+  path: [{ folderName: "root", folderId: ROOT_UUID }],
   items: [],
 };

--- a/frontend/src/packages/dashboard/state/folders/reducers.ts
+++ b/frontend/src/packages/dashboard/state/folders/reducers.ts
@@ -1,79 +1,90 @@
-import { PayloadAction } from '@reduxjs/toolkit';
-import { RenamePayloadType, SetDirPayloadType } from './actions';
-import { 
-  sliceState,
-  FileEntity,
-  Folder,
-  File
-} from './types';
+import { PayloadAction } from "@reduxjs/toolkit";
+import { RenamePayloadType, SetDirPayloadType } from "./actions";
+import { sliceState, FileEntity, Folder, File, PathObject } from "./types";
 
 /**
  * payload takes in:
  * array of type Folder || File
  */
-export function setItems(state: sliceState, action: PayloadAction<FileEntity[]>) {
-  const newEntityList: FileEntity[] = action.payload;
+export function setItems(
+  state: sliceState,
+  action: PayloadAction<FileEntity[]>
+) {
+  const newEntityList: FileEntity[] = [...action.payload];
   return {
     ...state,
-    items: newEntityList
-  }
+    items: newEntityList,
+  };
 }
 
-
-export function addFolderItems(state: sliceState, action: PayloadAction<Folder>) {
+export function addFolderItems(
+  state: sliceState,
+  action: PayloadAction<Folder>
+) {
   const newFolder: Folder = action.payload;
   return {
     ...state,
-    items: [
-      ...state.items, 
-      newFolder,
-    ]
-  }
+    items: [...state.items, newFolder],
+  };
 }
 
 export function addFileItems(state: sliceState, action: PayloadAction<File>) {
   const newFile: File = action.payload;
   return {
-    ...state, 
-    items: [
-      ...state.items, 
-      newFile,
-    ]
-  }
+    ...state,
+    items: [...state.items, newFile],
+  };
 }
 
-export function renameFileEntity(state: sliceState, action: PayloadAction<RenamePayloadType>) {
+export function renameFileEntity(
+  state: sliceState,
+  action: PayloadAction<RenamePayloadType>
+) {
   const { id, newName } = action.payload;
   return {
     ...state,
     items: state.items.map((item) => {
-      if(item.id == id) {
-        return ({
+      if (item.id == id) {
+        return {
           ...item,
           name: newName,
-        })
+        };
       }
       // else
       return item;
-    })
-  }
+    }),
+  };
 }
 
-export function setDirectory(state: sliceState, action: PayloadAction<SetDirPayloadType>) {
-  let pathDir = state.path;
+export function setDirectory(
+  state: sliceState,
+  action: PayloadAction<SetDirPayloadType>
+) {
+  // Helper function for setDirectory
+  // checks if current folder already in breadcrumb path
+  function folderInPathList(pathList: PathObject[], folderId: string): boolean {
+    for (const pathObj of pathList) {
+      if (pathObj.folderId === folderId) {
+        return true;
+      }
+    }
+    return false;
+  }
 
-  // traverse back to the previous folder
-  if (action.payload.folderName == '') {
-    pathDir = (pathDir.split("/")).slice(0, -1).join("/");
-  } else { // traverse into a folder
-    pathDir = pathDir + '/' + action.payload.folderName;
+  const pathList: PathObject[] = [...state.path];
+  const destFolderName: string = action.payload.folderName;
+  const destFolderId: string = action.payload.parentFolder;
+  if (folderInPathList(pathList, destFolderId)) {
+    while (pathList[pathList.length - 1].folderId !== destFolderId) {
+      pathList.pop();
+    }
+  } else {
+    pathList.push({ folderName: destFolderName, folderId: destFolderId });
   }
 
   return {
     ...state,
     parentFolder: action.payload.parentFolder,
-    path: pathDir
-  }
+    path: pathList,
+  };
 }
-
-

--- a/frontend/src/packages/dashboard/state/folders/types.ts
+++ b/frontend/src/packages/dashboard/state/folders/types.ts
@@ -14,8 +14,13 @@ export type File = {
 // folders and files
 export type FileEntity = Folder | File;
 
+export type PathObject = {
+  folderName: string;
+  folderId: string;
+};
+
 export type sliceState = {
   parentFolder: string;
-  path: string;
+  path: PathObject[];
   items: FileEntity[];
 };

--- a/frontend/src/packages/dashboard/state/folders/types.ts
+++ b/frontend/src/packages/dashboard/state/folders/types.ts
@@ -14,6 +14,8 @@ export type File = {
 // folders and files
 export type FileEntity = Folder | File;
 
+// PathObject is the type which specifies the name AND id of the
+// folder we are currently in
 export type PathObject = {
   folderName: string;
   folderId: string;


### PR DESCRIPTION
### Why the changes are required?
Breadcrumb pill path was not interactive and did not allow user to traverse the folder structure by clicking on it.
Repeatedly clicking on the root folder also caused the path to repeatedly print out 'root'.

### Changes
- Implemented breadcrumb pill clicking functionality by altering how path was stored: string path -> array of objects storing folderId and folderNames
- Using the above change to an array, the repeating root in path was also fixed by checking if a certain folderId already existed in the path array.
### Screenshots

### Comments
Now that the path is stored in an array of objects, the traverseBackFolderSaga can simply be replaced by traverseIntoFolderSaga, so can potentially be removed.