### PR TITLE
[WEB-32] [CMS] new file/folder name persistence issue fix

### DIFF
--- a/frontend/src/packages/dashboard/components/ConfirmationModal/ConfirmationWindow.tsx
+++ b/frontend/src/packages/dashboard/components/ConfirmationModal/ConfirmationWindow.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import { Modal, Typography, TextField, Box } from "@mui/material";
 import { useDispatch } from "react-redux";
@@ -43,6 +43,10 @@ export default function ConfirmationWindow({
   const dispatch = useDispatch();
   const [inputValue, setInputValue] = useState<string>("");
   const folderState = getFolderState();
+
+  useEffect(() => {
+    setInputValue("");
+  }, [modalState]);
 
   const handleSubmit = () => {
     switch (modalState.type) {


### PR DESCRIPTION
### Why is the change needed
Currently, when a user exits the new page / new folder modal, the input name persists in subsequent renders of the modal.

### Changes
- `frontend/src/packages/dashboard/components/ConfirmationModal/ConfirmationWindow.tsx` - added a `useEffect` hook which resets the state of the input value whenever the modal is opened or closed.

### Screenshots

https://github.com/csesoc/website/assets/79197816/54c27a8d-e437-4d4f-ac1d-a5b27a46a9c5

