### PR TITLE
Context Refactoring

### DIFF
--- a/backend/database/repositories/main.go
+++ b/backend/database/repositories/main.go
@@ -15,23 +15,23 @@ var context contexts.DatabaseContext = nil
 // Open constructors available for everyone
 
 // NewFilesystemRepo instantiates a new file system repository with the current embedded context
-func NewFilesystemRepo() FilesystemRepository {
+func NewFilesystemRepo(context contexts.DatabaseContext) FilesystemRepository {
 	return filesystemRepository{
-		embeddedContext{getContext()},
+		embeddedContext{context},
 	}
 }
 
 // NewGroupsRepo instantiates a new groups repository
-func NewGroupsRepo() GroupsRepository {
+func NewGroupsRepo(context contexts.DatabaseContext) GroupsRepository {
 	return groupsRepository{
-		embeddedContext{getContext()},
+		embeddedContext{context},
 	}
 }
 
 // NewFrontendsRepo instantiates a new frontends repository
-func NewFrontendsRepo() FrontendsRepository {
+func NewFrontendsRepo(context contexts.DatabaseContext) FrontendsRepository {
 	return frontendsRepository{
-		embeddedContext{getContext()},
+		embeddedContext{context},
 	}
 }
 

--- a/backend/database/repositories/tests/filesystem_test.go
+++ b/backend/database/repositories/tests/filesystem_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	repo        = repositories.NewFilesystemRepo()
+	repo        = repositories.NewFilesystemRepo(contexts.GetDatabaseContext())
 	testContext = repo.GetContext().(*contexts.TestingContext)
 )
 

--- a/backend/editor/diffSync/document/manager.go
+++ b/backend/editor/diffSync/document/manager.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"sync"
 
+	"cms.csesoc.unsw.edu.au/database/contexts"
 	"cms.csesoc.unsw.edu.au/database/repositories"
 	"cms.csesoc.unsw.edu.au/internal/storage"
 	"github.com/google/uuid"
@@ -21,7 +22,7 @@ type Manager struct {
 var (
 	managerInstance *Manager
 	lock            = &sync.Mutex{}
-	repo            = repositories.NewFilesystemRepo()
+	repo            = repositories.NewFilesystemRepo(contexts.GetDatabaseContext())
 )
 
 // implementation of the singleton pattern :)

--- a/backend/endpoints/dependency_factory.go
+++ b/backend/endpoints/dependency_factory.go
@@ -3,6 +3,7 @@ package endpoints
 //go:generate mockgen -source=dependency_factory.go -destination=mocks/dependency_factory_mock.go -package=mocks
 
 import (
+	"cms.csesoc.unsw.edu.au/database/contexts"
 	repos "cms.csesoc.unsw.edu.au/database/repositories"
 	"cms.csesoc.unsw.edu.au/internal/logger"
 )
@@ -31,17 +32,17 @@ type (
 
 // GetFilesystemRepo is the constructor for FS repos
 func (dp DependencyProvider) GetFilesystemRepo() repos.FilesystemRepository {
-	return repos.NewFilesystemRepo()
+	return repos.NewFilesystemRepo(contexts.GetDatabaseContext())
 }
 
 // GetGroupsRepo instantiates a new groups repository
 func (dp DependencyProvider) GetGroupsRepo() repos.GroupsRepository {
-	return repos.NewGroupsRepo()
+	return repos.NewGroupsRepo(contexts.GetDatabaseContext())
 }
 
 // GetFrontendsRepo instantiates a new frontend repository
 func (dp DependencyProvider) GetFrontendsRepo() repos.FrontendsRepository {
-	return repos.NewFrontendsRepo()
+	return repos.NewFrontendsRepo(contexts.GetDatabaseContext())
 }
 
 // GetPersonsRepo instantiates a new person repository

--- a/backend/endpoints/main.go
+++ b/backend/endpoints/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"cms.csesoc.unsw.edu.au/database/contexts"
 	"cms.csesoc.unsw.edu.au/database/repositories"
 	"cms.csesoc.unsw.edu.au/internal/logger"
 	"cms.csesoc.unsw.edu.au/internal/session"
@@ -123,7 +124,7 @@ func (fn rawHandler[T, V]) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // getFrontendID gets the frontend id for an incoming http request
 func getFrontendId(r *http.Request) int {
-	frontendRepo := repositories.NewFrontendsRepo()
+	frontendRepo := repositories.NewFrontendsRepo(contexts.GetDatabaseContext())
 	return frontendRepo.GetFrontendFromURL(r.URL.Host)
 }
 


### PR DESCRIPTION
Moving the construction of contexts outside of `Get___Repo()` functions into a parameter instead. This fixes a use case where uninitialised `Repo`s have a cyclical dependency on `TestingContext` (It's required to be defined, but cannot be at the same time).