### PR TITLE
Web 34 repository layer expose doc metadata

### DIFF
--- a/backend/database/repositories/filesystem.go
+++ b/backend/database/repositories/filesystem.go
@@ -24,7 +24,7 @@ func (rep filesystemRepository) query(query string, input ...interface{}) (Files
 	err := rep.ctx.Query(query,
 		input,
 		&entity.EntityID, &entity.LogicalName, &entity.IsDocument, &entity.IsPublished,
-		&entity.CreatedAt, &entity.OwnerUserId, &entity.ParentFileID)
+		&entity.CreatedAt, &entity.MetadataID, &entity.OwnerUserId, &entity.ParentFileID)
 	if err != nil {
 		return FilesystemEntry{}, err
 	}
@@ -110,6 +110,26 @@ func (rep filesystemRepository) GetIDWithPath(path string) (uuid.UUID, error) {
 	}
 
 	return parent.EntityID, err
+}
+
+func (rep filesystemRepository) GetMetadataFromID(ID uuid.UUID) (MetadataEntry, error) {
+	// Get entry from ID
+	metadataId, err := rep.GetEntryWithID(ID)
+	if err != nil {
+		return MetadataEntry{}, err
+	}
+
+	// Get metadata
+	entity := MetadataEntry{}
+
+	err = rep.ctx.Query("SELECT * FROM metadata WHERE MetadataID = $1",
+		[]interface{}{metadataId},
+		&entity.MetadataID, &entity.CreatedAt)
+	if err != nil {
+		return MetadataEntry{}, err
+	}
+	return entity, nil
+
 }
 
 func (rep filesystemRepository) DeleteEntryWithID(ID uuid.UUID) error {

--- a/backend/database/repositories/repository_interfaces.go
+++ b/backend/database/repositories/repository_interfaces.go
@@ -19,9 +19,16 @@ type FilesystemEntry struct {
 	IsPublished bool
 	CreatedAt   time.Time
 
+	MetadataID uuid.UUID
+
 	OwnerUserId  int
 	ParentFileID uuid.UUID
 	ChildrenIDs  []uuid.UUID
+}
+
+type MetadataEntry struct {
+	MetadataID uuid.UUID
+	CreatedAt  time.Time
 }
 
 type (
@@ -32,6 +39,7 @@ type (
 		GetRoot() (FilesystemEntry, error)
 		GetEntryWithParentID(ID uuid.UUID) (FilesystemEntry, error)
 		GetIDWithPath(path string) (uuid.UUID, error)
+		GetMetadataFromID(ID uuid.UUID) (MetadataEntry, error)
 
 		CreateEntry(file FilesystemEntry) (FilesystemEntry, error)
 		DeleteEntryWithID(ID uuid.UUID) error

--- a/backend/database/repositories/tests/filesystem_test.go
+++ b/backend/database/repositories/tests/filesystem_test.go
@@ -264,6 +264,28 @@ func TestGetIDWithPath(t *testing.T) {
 	})
 }
 
+func TestMetadataRetrieval(t *testing.T) {
+	assert := assert.New(t)
+
+	testContext.RunTest(func() {
+		// ==== Setup ====
+		newDoc, err := repo.CreateEntry(repositories.FilesystemEntry{
+			LogicalName: "test_doc", ParentFileID: repositories.FilesystemRootID,
+			OwnerUserId: repositories.GROUPS_ADMIN, IsDocument: true,
+		})
+		// ==== Assertions ====
+		if err != nil {
+			log.Fatalf(err.Error())
+		}
+
+		// Query for metadata in database
+		if info, err := repo.GetMetadataFromID(newDoc.EntityID); assert.Nil(err) {
+			assert.Equal(newDoc.MetadataID, info.MetadataID)
+			assert.NotEmpty(info.CreatedAt)
+		}
+	})
+}
+
 func scanArray[T any](rows pgx.Rows) []T {
 	arr := []T{}
 	for rows.Next() {

--- a/postgres/up/06-create_dummy_data.sql
+++ b/postgres/up/06-create_dummy_data.sql
@@ -10,11 +10,14 @@ DO $$
 DECLARE 
   randomGroup groups.UID%type;
   rootID      filesystem.EntityID%type;
+  newMetadataID  filesystem.MetadataID%type;
 BEGIN
   SELECT groups.UID INTO randomGroup FROM groups WHERE Name = 'admin'::VARCHAR;
+  /* Create metadata */
+  INSERT INTO metadata DEFAULT VALUES RETURNING MetadataID INTO newMetadataID;
   /* Insert the root directory */
-  INSERT INTO filesystem (EntityID, LogicalName, OwnedBy)
-    VALUES (uuid_nil(), 'root', randomGroup);
+  INSERT INTO filesystem (EntityID, LogicalName, MetadataID, OwnedBy)
+    VALUES (uuid_nil(), 'root', newMetadataID, randomGroup);
   SELECT filesystem.EntityID INTO rootID FROM filesystem WHERE LogicalName = 'root'::VARCHAR;
   /* Set parent to uuid_nil() because postgres driver has issue supporting NULL values */
   UPDATE filesystem SET Parent = uuid_nil() WHERE EntityID = rootID;


### PR DESCRIPTION
- Uncommented the foreign key constraint to the metadata table
- Updated entity creation stored procs to create metadata entries when creating new entities
- Added GetMetadataFromID in repository layer to expose document metadata
- Wrote test for GetMetadataFromID 