### PR TITLE
[WEB-65] [EDITOR] Make blog title editable within editor

### DIFF
--- a/frontend/src/cse-ui-kit/EditableTitle_textbox/EditableTitle-Styled.tsx
+++ b/frontend/src/cse-ui-kit/EditableTitle_textbox/EditableTitle-Styled.tsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import { InputHTMLAttributes } from "react"
 
 export type buttonProps = {
   background?: string;

--- a/frontend/src/cse-ui-kit/EditableTitle_textbox/EditableTitle-Styled.tsx
+++ b/frontend/src/cse-ui-kit/EditableTitle_textbox/EditableTitle-Styled.tsx
@@ -1,11 +1,5 @@
 import styled from "styled-components";
 
-export type buttonProps = {
-  background?: string;
-};
-// width: 175px;
-// height: 45px;
-// margin: 5px;
 export const StyledTextBox = styled.input`
   background: transparent;
 

--- a/frontend/src/cse-ui-kit/EditableTitle_textbox/EditableTitle-Styled.tsx
+++ b/frontend/src/cse-ui-kit/EditableTitle_textbox/EditableTitle-Styled.tsx
@@ -1,0 +1,31 @@
+import styled from "styled-components";
+
+export type buttonProps = {
+  background?: string;
+};
+// width: 175px;
+// height: 45px;
+// margin: 5px;
+export const StyledTextBox = styled.input`
+  background: transparent;
+
+  border: none;
+  border-color: transparent;
+
+  padding: 0.5em;
+
+  font-size: inherit;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  user-select: none;
+
+  &:hover {
+    color: black;
+    transform: scale(1.04);
+    cursor: pointer;
+  }
+
+  cursor: pointer;
+`;

--- a/frontend/src/cse-ui-kit/EditableTitle_textbox/EditableTitle-Styled.tsx
+++ b/frontend/src/cse-ui-kit/EditableTitle_textbox/EditableTitle-Styled.tsx
@@ -1,5 +1,4 @@
 import styled from "styled-components";
-import { InputHTMLAttributes } from "react"
 
 export type buttonProps = {
   background?: string;
@@ -13,19 +12,20 @@ export const StyledTextBox = styled.input`
   border: none;
   border-color: transparent;
 
+  
   padding: 0.5em;
-
+  
   font-size: inherit;
-
+  
   display: flex;
   justify-content: center;
   align-items: center;
   user-select: none;
-
+  
   &:hover {
+    cursor: text;
     color: black;
     transform: scale(1.04);
-    cursor: pointer;
   }
 
   cursor: pointer;

--- a/frontend/src/cse-ui-kit/EditableTitle_textbox/EditableTitle.tsx
+++ b/frontend/src/cse-ui-kit/EditableTitle_textbox/EditableTitle.tsx
@@ -1,0 +1,15 @@
+import React, { MouseEventHandler } from "react";
+import { StyledTextBox, buttonProps } from "./EditableTitle-Styled";
+import { AiFillEdit } from "react-icons/ai";
+
+type Props = {
+  onClick?: MouseEventHandler<HTMLDivElement>;
+  value: string
+} & buttonProps;
+
+export default function EditableTitle({ onClick, value, ...styleProps }: Props) {
+  return (
+    <StyledTextBox onClick={onClick} value={value} {...styleProps}/>
+  );
+}
+

--- a/frontend/src/cse-ui-kit/EditableTitle_textbox/EditableTitle.tsx
+++ b/frontend/src/cse-ui-kit/EditableTitle_textbox/EditableTitle.tsx
@@ -3,13 +3,14 @@ import { StyledTextBox, buttonProps } from "./EditableTitle-Styled";
 import { AiFillEdit } from "react-icons/ai";
 
 type Props = {
-  onClick?: MouseEventHandler<HTMLDivElement>;
+  onChange?: React.ChangeEventHandler<HTMLInputElement>;
+  onBlur?: React.FocusEventHandler<HTMLInputElement>
   value: string
 } & buttonProps;
 
-export default function EditableTitle({ onClick, value, ...styleProps }: Props) {
+export default function EditableTitle({ onChange, onBlur, value, ...styleProps }: Props) { 
   return (
-    <StyledTextBox onClick={onClick} value={value} {...styleProps}/>
+    <StyledTextBox onChange={onChange} onBlur={onBlur} value={value} {...styleProps}/>
   );
 }
 

--- a/frontend/src/cse-ui-kit/EditableTitle_textbox/EditableTitle.tsx
+++ b/frontend/src/cse-ui-kit/EditableTitle_textbox/EditableTitle.tsx
@@ -1,12 +1,11 @@
-import React, { MouseEventHandler } from "react";
-import { StyledTextBox, buttonProps } from "./EditableTitle-Styled";
-import { AiFillEdit } from "react-icons/ai";
+import React  from "react";
+import { StyledTextBox } from "./EditableTitle-Styled";
 
 type Props = {
   onChange?: React.ChangeEventHandler<HTMLInputElement>;
   onBlur?: React.FocusEventHandler<HTMLInputElement>
   value: string
-} & buttonProps;
+};
 
 export default function EditableTitle({ onChange, onBlur, value, ...styleProps }: Props) { 
   return (

--- a/frontend/src/cse-ui-kit/EditableTitle_textbox/index.ts
+++ b/frontend/src/cse-ui-kit/EditableTitle_textbox/index.ts
@@ -1,0 +1,3 @@
+import EditableTitle from './EditableTitle';
+
+export default EditableTitle;

--- a/frontend/src/packages/editor/index.tsx
+++ b/frontend/src/packages/editor/index.tsx
@@ -22,6 +22,12 @@ import CreateCodeBlock from "src/cse-ui-kit/CreateCodeBlock_button ";
 import IconButton from "@mui/material/IconButton";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 
+import {
+  RenamePayloadType,
+  renameFileEntityAction,
+} from "src/packages/dashboard/state/folders/actions";
+import { useDispatch } from "react-redux";
+
 const Container = styled.div`
   display: flex;
   flex-direction: column;
@@ -59,13 +65,13 @@ const EditorPage: FC = () => {
 
   const [savedFilename, setSavedFilename] = useState<string>(`${filename}`);
 
+  const dispatch = useDispatch();
   const updateFilename = () => {
-    if (filename !== savedFilename) {
-      console.log(`propagating name change from "${savedFilename}" to "${filename}"`);
+    if (filename !== savedFilename && id !== undefined) {
+      const newPayload: RenamePayloadType = { id, newName: filename };
+      dispatch(renameFileEntityAction(newPayload));
 
       setSavedFilename(`${filename}`);
-    } else {
-      console.log("no change detected, not updating filename");
     }
   }
 

--- a/frontend/src/packages/editor/index.tsx
+++ b/frontend/src/packages/editor/index.tsx
@@ -8,6 +8,8 @@ import CreateContentBlock from "src/cse-ui-kit/CreateContentBlock_button";
 import CreateHeadingBlock from "src/cse-ui-kit/CreateHeadingBlock_button";
 import SyncDocument from "src/cse-ui-kit/SyncDocument_button";
 import PublishDocument from "src/cse-ui-kit/PublishDocument_button";
+import EditableTitle from "src/cse-ui-kit/EditableTitle_textbox";
+
 import EditorHeader from "src/deprecated/components/Editor/EditorHeader";
 import { useParams, useLocation, useNavigate } from "react-router-dom";
 
@@ -109,7 +111,9 @@ const EditorPage: FC = () => {
             <IconButton aria-label="back" onClick={() => navigate(-1)} sx={{ 'paddingRight': '20px' }}>
               <ArrowBackIcon fontSize="inherit"/>
             </IconButton>
-            {filename}
+
+            <EditableTitle value={filename}/>
+
           </LeftContainer>
           <ButtonContainer>
             <SyncDocument onClick={() => syncDocument()} />

--- a/frontend/src/packages/editor/index.tsx
+++ b/frontend/src/packages/editor/index.tsx
@@ -61,16 +61,28 @@ const EditorPage: FC = () => {
 
   const state = useLocation().state as LocationState;
 
+  console.log(useLocation());
+
   const [filename, setFilename] = useState<string>(state != null ? state.filename : "");
 
   const [savedFilename, setSavedFilename] = useState<string>(`${filename}`);
 
+  const navigate = useNavigate();
   const dispatch = useDispatch();
   const updateFilename = () => {
     if (filename !== savedFilename && id !== undefined) {
       const newPayload: RenamePayloadType = { id, newName: filename };
       dispatch(renameFileEntityAction(newPayload));
-
+      
+      // Re-navigate to current page with new file name so that
+      // filename changes are persistent on reloads
+      navigate("/editor/" + id, { 
+        replace: false,
+        state: {
+          filename
+        } 
+      }), [navigate];
+  
       setSavedFilename(`${filename}`);
     }
   }
@@ -121,7 +133,6 @@ const EditorPage: FC = () => {
     opManager.current?.pushToServer(newCreationOperation(newElement, blocks.length));
   }  
 
-  const navigate = useNavigate();
   
   return (
     <div style={{ height: "100%" }}>

--- a/frontend/src/packages/editor/index.tsx
+++ b/frontend/src/packages/editor/index.tsx
@@ -54,7 +54,20 @@ const EditorPage: FC = () => {
   const [focusedId, setFocusedId] = useState<number>(0);
 
   const state = useLocation().state as LocationState;
-  const filename = state != null ? state.filename : "";
+
+  const [filename, setFilename] = useState<string>(state != null ? state.filename : "");
+
+  const [savedFilename, setSavedFilename] = useState<string>(`${filename}`);
+
+  const updateFilename = () => {
+    if (filename !== savedFilename) {
+      console.log(`propagating name change from "${savedFilename}" to "${filename}"`);
+
+      setSavedFilename(`${filename}`);
+    } else {
+      console.log("no change detected, not updating filename");
+    }
+  }
 
   const updateValues: UpdateCallback = (idx, updatedBlock) => {
     const requiresUpdate = JSON.stringify(blocks[idx]) !== JSON.stringify(updateValues);
@@ -112,7 +125,13 @@ const EditorPage: FC = () => {
               <ArrowBackIcon fontSize="inherit"/>
             </IconButton>
 
-            <EditableTitle value={filename}/>
+            <EditableTitle 
+              value={filename}
+              onChange={(event) => {
+                setFilename(event.target.value)
+              }}
+              onBlur={updateFilename}
+            />
 
           </LeftContainer>
           <ButtonContainer>

--- a/frontend/src/packages/editor/index.tsx
+++ b/frontend/src/packages/editor/index.tsx
@@ -68,7 +68,11 @@ const EditorPage: FC = () => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
   const updateFilename = () => {
-    if (filename !== savedFilename && id !== undefined) {
+    // No empty names allowed!
+    if (filename == "") {
+      setFilename(savedFilename);
+      
+    } else if (filename !== savedFilename && id !== undefined) {
       const newPayload: RenamePayloadType = { id, newName: filename };
       dispatch(renameFileEntityAction(newPayload));
       

--- a/frontend/src/packages/editor/index.tsx
+++ b/frontend/src/packages/editor/index.tsx
@@ -61,8 +61,6 @@ const EditorPage: FC = () => {
 
   const state = useLocation().state as LocationState;
 
-  console.log(useLocation());
-
   const [filename, setFilename] = useState<string>(state != null ? state.filename : "");
 
   const [savedFilename, setSavedFilename] = useState<string>(`${filename}`);
@@ -77,12 +75,12 @@ const EditorPage: FC = () => {
       // Re-navigate to current page with new file name so that
       // filename changes are persistent on reloads
       navigate("/editor/" + id, { 
-        replace: false,
+        replace: true,
         state: {
           filename
         } 
       }), [navigate];
-  
+      
       setSavedFilename(`${filename}`);
     }
   }
@@ -138,7 +136,10 @@ const EditorPage: FC = () => {
     <div style={{ height: "100%" }}>
       <EditorHeader>
           <LeftContainer>
-            <IconButton aria-label="back" onClick={() => navigate(-1)} sx={{ 'paddingRight': '20px' }}>
+            <IconButton 
+              aria-label="back"
+              onClick={() => navigate(-1)} 
+              sx={{ 'paddingRight': '20px' }}>
               <ArrowBackIcon fontSize="inherit"/>
             </IconButton>
 


### PR DESCRIPTION
## Why the changes are needed
Currently there is no way to edit a document's filename while inside the editor.

## Changes
I took inspiration from Google Docs and made it so that when a user hovers over the filename in the editor, the cursor turns into an I-beam and the title slightly enlarges. This indicates to the user that the title is editable. Then upon clicking, the title visibly becomes a text box which users can write into. Once they are done renaming, they click out of the text box and the new filename is saved :D 

### File changes summary
- `frontend/src/cse-ui-kit/EditableTitle_textbox/*` - new component defining the custom text box for the editable file name
- `frontend/src/packages/editor/index.tsx` - integrated code to support file renaming. Reused code from `frontend/src/packages/dashboard/components/FileRenderer/Renamable.tsx` to update the redux state to ensure the new file name is propagated globally.

### Demo

https://github.com/csesoc/website/assets/79197816/4ce878c9-88cd-4abb-9dcf-664f2514bac5

