### PR TITLE
[WEB-66] Fix Files and Folders Don't Wrap When Resizing Screen

### DIFF
--- a/frontend/src/packages/dashboard/components/FileRenderer/FileContainer.tsx
+++ b/frontend/src/packages/dashboard/components/FileRenderer/FileContainer.tsx
@@ -4,10 +4,10 @@
 // Wraps the contents of a file stored on the CMS into its own
 // functional component, with hovering capabilities
 
-import React from "react";
-import styled, { css } from "styled-components";
-import { useNavigate } from "react-router-dom";
-import Renamable from "./Renamable";
+import React from 'react';
+import styled, { css } from 'styled-components';
+import { useNavigate } from 'react-router-dom';
+import Renamable from './Renamable';
 
 type Props = {
   name: string;
@@ -32,9 +32,10 @@ const IconContainer = styled.div<styledProps>`
   text-align: center;
   margin-bottom: 10px;
   cursor: pointer;
+  margin: 20px;
 
   border: ${(props) =>
-    props.active ? "3px solid red" : "3px solid var(--background-color)"};
+    props.active ? '3px solid red' : '3px solid var(--background-color)'};
 `;
 
 function FileContainer({ name, id, selectedFile, setSelectedFile }: Props) {
@@ -48,22 +49,23 @@ function FileContainer({ name, id, selectedFile, setSelectedFile }: Props) {
     console.log(id);
     setSelectedFile(id);
     if (selectedFile !== null) {
-      navigate("/editor/" + selectedFile, { 
+      navigate('/editor/' + selectedFile, {
         replace: false,
         state: {
-          filename: name
-        } 
-      }), [navigate];
+          filename: name,
+        },
+      }),
+        [navigate];
     }
   };
 
   return (
     <div
       style={{
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        padding: "35px",
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        width: '140px',
       }}
     >
       <IconContainer

--- a/frontend/src/packages/dashboard/components/FileRenderer/FolderContainer.tsx
+++ b/frontend/src/packages/dashboard/components/FileRenderer/FolderContainer.tsx
@@ -18,6 +18,7 @@ const IconContainer = styled.div`
   align-items: center;
   margin: 20px;
   text-align: center;
+  // border: black solid 1px;
 `;
 
 interface HighlightProps {

--- a/frontend/src/packages/dashboard/components/FileRenderer/FolderContainer.tsx
+++ b/frontend/src/packages/dashboard/components/FileRenderer/FolderContainer.tsx
@@ -18,7 +18,6 @@ const IconContainer = styled.div`
   align-items: center;
   margin: 20px;
   text-align: center;
-  // border: black solid 1px;
 `;
 
 interface HighlightProps {

--- a/frontend/src/packages/dashboard/components/FileRenderer/Renderer.tsx
+++ b/frontend/src/packages/dashboard/components/FileRenderer/Renderer.tsx
@@ -48,6 +48,7 @@ export default function Renderer({ selectedFile, setSelectedFile }: Props) {
     <div
       style={{
         display: 'flex',
+        flexWrap: 'wrap',
       }}
     >
       {renderItems()}


### PR DESCRIPTION
### Why the changes are required?
Currently the files and folders overflow off the side of the screen (as shown below). They should instead wrap around in a sort of grid manner.

### Changes
- Folders and Files now wrap around when screen is resized
- Folders and files line up in a grid system, where each takes 140px by 161px
### Screenshots
![image](https://github.com/csesoc/website/assets/86332745/282d4cd5-9e06-4466-bdd6-79e095ef95f0)

### Comments