### PR TITLE
[CMS] autofocus input box for new file/folder names

### DIFF
--- a/frontend/src/packages/dashboard/components/ConfirmationModal/ConfirmationWindow.tsx
+++ b/frontend/src/packages/dashboard/components/ConfirmationModal/ConfirmationWindow.tsx
@@ -123,6 +123,7 @@ export default function ConfirmationWindow({
                             onChange={handleChange}
                             onKeyDown={handleKeyDown}
                             sx={{ marginRight: '10px' }}
+                            autoFocus
                         />
                         <Button background="#73EEDC" onClick={handleSubmit}>
                             submit

--- a/frontend/src/packages/dashboard/components/ConfirmationModal/ConfirmationWindow.tsx
+++ b/frontend/src/packages/dashboard/components/ConfirmationModal/ConfirmationWindow.tsx
@@ -124,6 +124,7 @@ export default function ConfirmationWindow({
                             onKeyDown={handleKeyDown}
                             sx={{ marginRight: '10px' }}
                             autoFocus
+                            autoComplete='off'
                         />
                         <Button background="#73EEDC" onClick={handleSubmit}>
                             submit


### PR DESCRIPTION
# Why are the changes needed?
Currently, when the user opens the _New File_ or _New Modal_ modal, the text box to input the new file/folder name is unfocused by default. Also, when typing a new file name, the browser provides autocomplete suggestions based on previous inputs, which are mostly irrelevant in this context.

# Changes
- Added `autoFocus` and `autoComplete = 'off'`  to the `TextField` in `ConfirmationModal.tsx` to enable auto focus and disable autocomplete.