### PR TITLE
Fix parsing form file reflection error

### DIFF
--- a/backend/endpoints/form_parsers.go
+++ b/backend/endpoints/form_parsers.go
@@ -59,7 +59,8 @@ func parseFormFiles(r *http.Request, target interface{}) error {
 
 		if field.Type() == formFileType {
 			// Parse the incoming form file
-			uploadedFile, _, err := r.FormFile(field.Type().Name())
+			fileName := v.Type().Field(i).Name
+			uploadedFile, _, err := r.FormFile(fileName)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Originally there as an error parsing uploaded image requests. This is because `field.Type().Name()` returns a `string` of the field type and so an error was thrown from trying to read a non-existing file from the request.

Correcting this to `v.Type().Field(i).Name` changes it to a `string` of the field name.